### PR TITLE
Don't order by group by

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -247,7 +247,7 @@ export function getOrder(
     ELSE ${orderByArray.length + 1} 
 END;`;
   } else {
-    orderBy = groupBy.join(", ");
+    orderBy = "";
   }
   return orderBy;
 }


### PR DESCRIPTION
Previously I was seeing different sort orders from the client and server rendered charts (e.g., duckdb-wasm v.s. duckdb), but I'm unable to replicate that. Removing for now, but should keep an eye out!