### PR TITLE
Fix x sort options

### DIFF
--- a/src/getPlotOptions.ts
+++ b/src/getPlotOptions.ts
@@ -23,6 +23,11 @@ const borderOptions = {
 export function getMarkOptions(
   currentColumns: string[] = [],
   type: ChartType,
+  colTypes:
+    | {
+        [key: string]: BasicColumnType;
+      }
+    | undefined,
   options: {
     color?: string;
     xLabel?: string;
@@ -58,6 +63,8 @@ export function getMarkOptions(
     if (!label || label.length < length) return label;
     return label.slice(0, length) + ellipsis;
   }
+  const xSort = colTypes?.x !== "string" ? { sort: (d: any) => d.x } : {};
+
   return {
     // Create custom labels for x and y (important if the labels are custom but hidden!)
     channels: {
@@ -73,7 +80,7 @@ export function getMarkOptions(
     },
     ...tip,
     ...(type === "line" ? { stroke } : { fill }),
-    ...(currentColumns.includes("x") ? { x: `x`, sort: (d: any) => d.x } : {}),
+    ...(currentColumns.includes("x") ? { x: `x`, ...xSort } : {}),
     ...(currentColumns.includes("fy") ? { fy: "fy" } : {}),
     ...(type === "dot" && currentColumns.includes("r") ? { r: "r" } : {}),
     ...(type === "text" && currentColumns.includes("text")

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,12 +298,13 @@ export class DuckPlot {
         ...(this._text.column ? { text: this._text.column } : {}),
       };
       this._newDataProps = false;
+      this._visibleSeries = []; // reset visible series
       return this._chartData;
     }
     if (!this._ddb || !this._table)
       throw new Error("Database and table not set");
     // TODO: this error isn't being thrown when I'd expect (e.g, if type is not set)
-    if (!this._mark) throw new Error("Type not set");
+    if (!this._mark) throw new Error("Mark type not set");
     this._newDataProps = false;
     this._visibleSeries = []; // reset visible series
     const columns = {
@@ -355,6 +356,7 @@ export class DuckPlot {
     const primaryMarkOptions = getMarkOptions(
       currentColumns,
       this._mark.markType,
+      types,
       {
         color: isColor(this._color.column) ? this._color.column : undefined,
         tip: this._isServer ? false : this._config?.tip, // don't allow tip on the server


### PR DESCRIPTION
Previously, the plot options specified that `x` should be sorted by the `x` column:

```js
sort: (d: any) => d.x 
```
This makes sense for continuous values, but categorical values may have their own data order (which this was overwriting). If you had a specific order set, it was getting overwritten, yielding charts like this:
<img width="494" alt="Screenshot 2024-10-31 at 12 42 55 PM" src="https://github.com/user-attachments/assets/601d4982-03c6-480a-a5e8-144eee6e935f">

Now they're like this!


<img width="493" alt="Screenshot 2024-10-31 at 12 42 35 PM" src="https://github.com/user-attachments/assets/af5ed436-c520-4849-b7db-813928774e36">
