### PR TITLE
Support passing in tip labels

### DIFF
--- a/examples/plots/line.js
+++ b/examples/plots/line.js
@@ -9,6 +9,12 @@ duckplot
   .mark("line")
   .color("red")
   .options({width: 400, height: 500, y: {domain: [100, 30000]}})
+  .config({
+    tipLabels: {
+      x: "My cool x label, and it still get truncated",
+      y: "Test label"
+    }
+  })
 `;
 
 export const line = (options) => renderPlot("income.csv", codeString, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,8 +360,9 @@ export class DuckPlot {
       {
         color: isColor(this._color.column) ? this._color.column : undefined,
         tip: this._isServer ? false : this._config?.tip, // don't allow tip on the server
-        xLabel: plotOptions.x?.label ?? "",
-        yLabel: plotOptions.y?.label ?? "",
+        xLabel: this._config.tipLabels?.x ?? plotOptions.x?.label ?? "",
+        yLabel: this._config.tipLabels?.y ?? plotOptions.y?.label ?? "",
+        // TODO: suppport colorLabel
         markOptions: this._mark.options,
       }
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,12 @@ export type Config = {
   xLabelDisplay?: boolean;
   yLabelDisplay?: boolean;
   tip?: boolean; // Show tooltips
+  // For use in the tooltip
+  tipLabels?: {
+    x?: string;
+    y?: string;
+    color?: string;
+  };
   autoMargin?: boolean; // Automatically adjust margins
   aggregate?: Aggregate;
   interactiveLegend?: boolean;


### PR DESCRIPTION
You can now pass in custom labels to appear in tooltips by setting the `.config({tipLabels:...})` property for `x` and `y`. 
<img width="507" alt="Screenshot 2024-10-31 at 1 18 03 PM" src="https://github.com/user-attachments/assets/501e1251-cbf7-4d41-882c-e026cb748dd0">
