### PR TITLE
Don't do an x Sort on barX charts

### DIFF
--- a/src/getPlotOptions.ts
+++ b/src/getPlotOptions.ts
@@ -69,7 +69,10 @@ export function getMarkOptions(
     if (!label || label.length < length) return label;
     return label.slice(0, length) + ellipsis;
   }
-  const xSort = colTypes?.x !== "string" ? { sort: (d: any) => d.x } : {};
+  const xSort =
+    colTypes?.x !== "string" && type !== "barX"
+      ? { sort: (d: any) => d.x }
+      : {};
 
   return {
     // Create custom labels for x and y (important if the labels are custom but hidden!)


### PR DESCRIPTION
Removes the plot option to sort along the X axis if you're looking at a `barX` chart. Doing so enforces an undesired order on the elements if there is a category, as in this example:

<img width="464" alt="Screenshot 2024-11-04 at 4 02 56 PM" src="https://github.com/user-attachments/assets/9eed11e8-8853-4d8b-948b-514700c58067">
