### PR TITLE
Support custom sorts

### DIFF
--- a/examples/plots/index.js
+++ b/examples/plots/index.js
@@ -28,5 +28,7 @@ export * from "./percentageBarX.js";
 export * from "./percentageBarY.js";
 export * from "./percentageFacet.js";
 export * from "./rawData.js";
+export * from "./sortXbyY.js";
+export * from "./sortYbyX.js";
 export * from "./text.js";
 export * from "./xLabelRotate.js";

--- a/examples/plots/sortXbyY.js
+++ b/examples/plots/sortXbyY.js
@@ -1,0 +1,12 @@
+import { renderPlot } from "../util/renderPlotClient.js";
+// This code is both displayed in the browser and executed
+
+const codeString = `duckplot
+  .table("stocks")
+  .x("Symbol")
+  .y("Close")
+  .config({aggregate: "avg"})
+  .mark("barY", {sort: {x: "y", reverse: true, limit: 3}});`;
+
+export const sortXbyY = (options) =>
+  renderPlot("stocks.csv", codeString, options);

--- a/examples/plots/sortYbyX.js
+++ b/examples/plots/sortYbyX.js
@@ -1,0 +1,12 @@
+import { renderPlot } from "../util/renderPlotClient.js";
+// This code is both displayed in the browser and executed
+
+const codeString = `duckplot
+  .table("stocks")
+  .x("Close")
+  .y("Symbol")
+  .config({aggregate: "avg"})
+  .mark("barX", {sort: {y: "x", reverse: true, limit: 3}});`;
+
+export const sortYbyX = (options) =>
+  renderPlot("stocks.csv", codeString, options);

--- a/src/getPlotOptions.ts
+++ b/src/getPlotOptions.ts
@@ -72,8 +72,9 @@ export function getMarkOptions(
     if (!label || label.length < length) return label;
     return label.slice(0, length) + ellipsis;
   }
-  const xSort =
-    colTypes?.x !== "string" && type !== "barX"
+
+  const sort =
+    options.markOptions?.sort ?? (colTypes?.x !== "string" && type !== "barX")
       ? { sort: (d: any) => d.x }
       : {};
 
@@ -97,7 +98,8 @@ export function getMarkOptions(
     },
     ...tip,
     ...(type === "line" ? { stroke } : { fill }),
-    ...(currentColumns.includes("x") ? { x: `x`, ...xSort } : {}),
+    ...(currentColumns.includes("x") ? { x: `x` } : {}),
+    ...(sort ? sort : {}),
     ...(currentColumns.includes("fy") ? { fy: "fy" } : {}),
     ...(type === "dot" && currentColumns.includes("r") ? { r: "r" } : {}),
     ...(type === "text" && currentColumns.includes("text")

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,6 +374,7 @@ export class DuckPlot {
               primaryMarkOptions as MarkOptions
             ),
           ];
+
     // TODO: double check you don't actually use border color
     // TODO: Make frame/grid config options(?)
     const commonPlotMarks = [
@@ -441,9 +442,11 @@ export class DuckPlot {
       ? Object.keys(this._chartData.types)
       : []; // TODO: remove this arg from topLevelPlotOptions
     const document = this._isServer ? this._jsdom!.window.document : undefined;
-    // TODO: custom sorts as inputs?
+    // Because the sort can be specified in the options, remove any colums who
+    // have a sort specified
+    const haveSorts = Object.keys(this._mark?.options?.sort ?? {});
     let sorts = getSorts(
-      currentColumns.filter((d) => d !== "fy"),
+      currentColumns.filter((d) => d !== "fy" && !haveSorts.includes(d)),
       this._chartData,
       this._color.options?.type === "categorical"
     );


### PR DESCRIPTION
Users can now specify a `sort` argument as one of the mark options and it will be respected. This is just passing through a Plot argument. 

For example, sorting the x axis by the y value (and reversing it, and limiting the number of rows!)
<img width="551" alt="Screenshot 2024-11-08 at 10 57 27 AM" src="https://github.com/user-attachments/assets/62624832-e5b5-4d9a-becd-340f7fd69a53">
