### PR TITLE
Enable tick marks

### DIFF
--- a/examples/plots/index.js
+++ b/examples/plots/index.js
@@ -31,4 +31,5 @@ export * from "./rawData.js";
 export * from "./sortXbyY.js";
 export * from "./sortYbyX.js";
 export * from "./text.js";
+export * from "./tick.js";
 export * from "./xLabelRotate.js";

--- a/examples/plots/line.js
+++ b/examples/plots/line.js
@@ -1,6 +1,6 @@
 import { renderPlot } from "../util/renderPlotClient.js";
 // This code is both displayed in the browser and executed
-const codeString = `// Standard area chart
+const codeString = `// Standard line chart
 duckplot
   .table("stocks")
   .x("Date")

--- a/examples/plots/tick.js
+++ b/examples/plots/tick.js
@@ -1,0 +1,11 @@
+import { renderPlot } from "../util/renderPlotClient.js";
+// This code is both displayed in the browser and executed
+const codeString = `duckplot
+    .table("stocks")
+    .x("Date")    
+    .fy("Symbol")
+    .color("Close")   
+    .mark("tickX")
+    `;
+
+export const tick = (options) => renderPlot("stocks.csv", codeString, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,7 +364,12 @@ export class DuckPlot {
     // Here, we want to add the primary mark if x and y are defined OR if an
     // aggregate has been specifid. Not a great rule, but works for now for
     // showing aggregate marks with only one dimension
+    const isValidTickChart =
+      (this._mark.markType === "tickX" && currentColumns.includes("x")) ||
+      (this._mark.markType === "tickY" && currentColumns.includes("y"));
+
     const primaryMark =
+      !isValidTickChart &&
       (!currentColumns.includes("x") || !currentColumns.includes("y")) &&
       !this._config.aggregate
         ? []

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,15 @@
 import type { MarkOptions, PlotOptions } from "@observablehq/plot";
 
 // TODO: all plot chart types?
-export type ChartType = "dot" | "areaY" | "line" | "barX" | "barY" | "text";
+export type ChartType =
+  | "dot"
+  | "areaY"
+  | "line"
+  | "barX"
+  | "barY"
+  | "text"
+  | "tickX"
+  | "tickY";
 
 export type SqlSort = {
   column: string;


### PR DESCRIPTION
Previously, tick marks weren't being rendered as they were falsely identified as a "partial chart". This PR checks for valid tick charts when getting the primary mark options. 