### PR TITLE
Improve handling of title casing

### DIFF
--- a/src/prepareChartData.ts
+++ b/src/prepareChartData.ts
@@ -4,6 +4,7 @@ import {
   ChartData,
   ChartType,
   ColumnConfig,
+  ColumnType,
   DescribeSchema,
   Indexable,
   QueryMap,
@@ -11,6 +12,7 @@ import {
 import {
   columnIsDefined,
   getAggregateInfo,
+  getLabel,
   getTransformQuery,
   toTitleCase,
 } from "./query";
@@ -136,21 +138,14 @@ export async function prepareChartData(
   let formatted: ChartData = formatResults(data, schema);
 
   if (!labels!.series) {
-    labels!.series = toTitleCase(
-      Array.isArray(config.series)
-        ? config.series?.filter((d) => d)?.join(", ")
-        : config.series
-    );
+    labels!.series = getLabel(config.series);
   }
   if (!labels!.x) {
-    labels!.x = config.fx ? toTitleCase(config.fx) : toTitleCase(config.x);
+    // Use the fx label for grouped bar charts
+    labels!.x = getLabel(config.fx ?? config.x);
   }
   if (!labels!.y) {
-    labels!.y = toTitleCase(
-      Array.isArray(config.y)
-        ? config.y?.filter((d) => d)?.join(", ")
-        : config.y
-    );
+    labels!.y = getLabel(config.y);
   }
   formatted.labels = labels;
   // Drop the reshaped table

--- a/src/query.ts
+++ b/src/query.ts
@@ -212,14 +212,14 @@ export function getAggregateInfo(
   if (type === "barX") {
     if (x && x.length > 0 && aggregate !== false) {
       aggregateSelection = ` ${agg}(x::FLOAT) as x`;
-      labels.x = `${toTitleCase(agg)} of ${toTitleCase(x)}`;
+      labels.x = `${capitalize(agg)} of ${getLabel(x)}`;
     }
     groupBy = columns.filter((d) => d !== "x");
   } else {
     if (y && y.length > 0 && aggregate !== false) {
       // First aggregation (mean, sum, etc.)
       aggregateSelection = ` ${agg}(y::FLOAT) as y`;
-      labels.y = `${toTitleCase(agg)} of ${toTitleCase(y)}`;
+      labels.y = `${capitalize(agg)} of ${getLabel(y)}`;
     }
     groupBy = columns.filter((d) => d !== "y");
   }
@@ -358,11 +358,25 @@ export function toTitleCase(value?: string | unknown) {
   // Add space before uppercase letters (for camel case) and ensure the first character is not unnecessarily spaced
   result = result.replace(/([a-z])([A-Z])/g, "$1 $2").trim();
 
-  // Capitalize the first letter of each word
-  result = result
-    .toLowerCase()
-    .split(" ")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-  return result;
+  // Capitalize the first letter of each word (if more than one word)
+  return !result.includes(" ")
+    ? result
+    : result.toLowerCase().split(" ").map(capitalize).join(" ");
+}
+
+function capitalize(str: string | boolean) {
+  if (typeof str === "boolean") return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+// Get a series/axis label - if there are multiple columns, we should title case
+// the defined columns and join them with a comma. If there is only one column,
+// it should be title cased
+export function getLabel(columnSpec: ColumnType | undefined): string {
+  return Array.isArray(columnSpec)
+    ? columnSpec
+        ?.filter((d) => d)
+        .map(toTitleCase) // title case each one before joining
+        ?.join(", ")
+    : toTitleCase(columnSpec);
 }

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -13,6 +13,7 @@ import {
   quoteColumns,
   standardColName,
   toTitleCase,
+  getLabel,
 } from "../src/query";
 
 function removeSpacesAndBreaks(str: string) {
@@ -463,12 +464,32 @@ describe("quoteColumns", () => {
 });
 
 describe("toTitleCase", () => {
-  it("should convert string to title case", () => {
-    expect(toTitleCase("some_title_case")).toBe("Some Title Case");
+  it("should not change single words (without spaces, dashes, or underscores)", () => {
+    expect(toTitleCase("DAU")).toBe("DAU");
+  });
+
+  it("should convert strings with implied spaces to title case", () => {
+    expect(toTitleCase("some_column_name")).toBe("Some Column Name");
+    expect(toTitleCase("someColumnName")).toBe("Some Column Name");
+    expect(toTitleCase("some-column-name")).toBe("Some Column Name");
+    expect(toTitleCase("some column name")).toBe("Some Column Name");
+    expect(toTitleCase("SOME COLUMN NAME")).toBe("Some Column Name");
   });
 
   it("should handle empty input gracefully", () => {
     expect(toTitleCase()).toBe("");
+  });
+});
+
+describe("getLabel", () => {
+  it("should return the title case of a single value", () => {
+    expect(getLabel("DAU")).toBe(toTitleCase("DAU"));
+  });
+  it("should first title case each column then join them", () => {
+    const columns = ["columnOne", "columnTwo"];
+    const expected = columns.map(toTitleCase).join(", ");
+    expect(getLabel(columns)).toBe(expected);
+    expect(getLabel(["AAPL", "GOOG"])).toBe("AAPL, GOOG");
   });
 });
 


### PR DESCRIPTION
The `toTitleCase` function that was generating axis labels would previously apply the title casing to single words, so `AAPL` would become `Aapl`, which isn't desirable. As is now expressed in the tests, 
- `toTitleCase` only title cases each word
- `getLabel` (a new function) first applies the title casing and then joins the columns together (so each column is handled independently). 

Solves this awful inconsistency. 
![image](https://github.com/user-attachments/assets/b0374203-d8f5-4464-9500-5521b6a8ede9)
