### PR TITLE
Remove quotes around table name

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -85,7 +85,7 @@ export function getUnpivotQuery(
   // created through multiple y columns
   return `${createStatment} ${selectStr}, ${rStr}${textStr}${fyStr} key AS series${
     fx && !x ? ", key AS x" : ""
-  } FROM "${tableName}"
+  } FROM ${tableName}
         UNPIVOT (value FOR key IN (${keysStr}));`;
 }
 


### PR DESCRIPTION
There was one instance that (erroneously) included double quotes around the table name in the query. This was causing an issue when users provided a table name with a catalog that included an underscore in it (e.g., `my_catalog.tablename`).