### PR TITLE
Stringify tick labels

### DIFF
--- a/src/getPlotOptions.ts
+++ b/src/getPlotOptions.ts
@@ -338,8 +338,9 @@ export function getTickFormatter(
 ) {
   if (colType === "string") {
     return {
-      tickFormat: (text: string) =>
-        truncateText(text, direction, width, height),
+      tickFormat: (value: unknown) => {
+        return truncateText(String(value), direction, width, height);
+      },
     };
   }
   return {};


### PR DESCRIPTION
Previously `null` values in string columns were breaking axis labels. This PR stringifies the values for string columns to display them correctly. 