### PR TITLE
Add explicit tip mark

### DIFF
--- a/examples/plots/rawData.js
+++ b/examples/plots/rawData.js
@@ -1,11 +1,10 @@
 import { renderPlot } from "../util/renderPlotClient.js";
 // This code is both displayed in the browser and executed
-const codeString = `
-duckplot
+const codeString = `duckplot
   .rawData([{col1: "a", col2: 5}, {col1: "b", col2: 2}, {col1: "c", col2: 3}], {col1: "string", col2: "number"})
   .x("col1")
   .y("col2")
-  .color("col1")
+  .color("col2")
   .fy("col1")
   .mark("barY")
 `;

--- a/src/options/getAllMarkOptions.ts
+++ b/src/options/getAllMarkOptions.ts
@@ -70,9 +70,10 @@ export function getAllMarkOptions(instance: DuckPlot) {
     plotOptions.fy
   );
   const tipMark =
-    instance.isServer || instance.config()?.tip === false
+    instance.isServer || instance.config()?.tip === false || !showPrimaryMark
       ? []
       : [getTipMark(instance)];
+
   return [
     ...(commonPlotMarks || []),
     ...(primaryMark || []),

--- a/src/options/getAllMarkOptions.ts
+++ b/src/options/getAllMarkOptions.ts
@@ -5,6 +5,8 @@ import { derivePlotOptions } from "./derivePlotOptions";
 import { getPrimaryMarkOptions } from "./getPrimaryMarkOptions";
 import * as Plot from "@observablehq/plot";
 import { getCommonMarks, getfyMarks } from "./getPlotOptions";
+import { ChartType } from "../types";
+import { getTipMark } from "./getTipMark";
 export function getAllMarkOptions(instance: DuckPlot) {
   // Grab the types and labels from the data
   const { types, labels } = instance.data();
@@ -67,9 +69,14 @@ export function getAllMarkOptions(instance: DuckPlot) {
     currentColumns,
     plotOptions.fy
   );
+  const tipMark =
+    instance.isServer || instance.config()?.tip === false
+      ? []
+      : [getTipMark(instance)];
   return [
     ...(commonPlotMarks || []),
     ...(primaryMark || []),
     ...(fyMarks || []),
+    ...tipMark,
   ];
 }

--- a/src/options/getPrimaryMarkOptions.ts
+++ b/src/options/getPrimaryMarkOptions.ts
@@ -1,15 +1,10 @@
 import { MarkOptions } from "@observablehq/plot";
 import { DuckPlot } from "..";
 import { isColor } from "./getPlotOptions";
-import { borderOptions, defaultColors } from "../helpers";
+import { defaultColors } from "../helpers";
 
 // Get options for a specific mark (e.g., the line or area marks)
 export function getPrimaryMarkOptions(instance: DuckPlot) {
-  const plotOptions = instance.derivePlotOptions();
-  const xLabel = instance.config().tipLabels?.x ?? plotOptions.x?.label ?? "",
-    yLabel = instance.config().tipLabels?.y ?? plotOptions.y?.label ?? "",
-    xValue = instance.config().tipValues?.x,
-    yValue = instance.config().tipValues?.y;
   // Grab the types from the data
   const { types } = instance.data();
   const type = instance.mark().type;
@@ -22,29 +17,6 @@ export function getPrimaryMarkOptions(instance: DuckPlot) {
 
   const fill = currentColumns.includes("series") ? "series" : color;
   const fx = currentColumns.includes("fx") ? "fx" : undefined;
-  const tip =
-    !instance.isServer && instance.config()?.tip !== false
-      ? {
-          tip: {
-            stroke: borderOptions.borderColor,
-            format: {
-              xCustom: true,
-              yCustom: true,
-              x: false,
-              y: false,
-              color: true,
-              fy: false,
-              fx: false,
-              z: false, // Hide the auto generated "series" for area charts
-            },
-          },
-        }
-      : {};
-  const ellipsis = "…";
-  function truncateLabel(label: string | undefined, length: number = 25) {
-    if (!label || label.length < length) return label;
-    return label.slice(0, length) + ellipsis;
-  }
 
   const sort =
     instance.mark().options?.sort ?? (types?.x !== "string" && type !== "barX")
@@ -52,24 +24,6 @@ export function getPrimaryMarkOptions(instance: DuckPlot) {
       : {};
 
   return {
-    // Create custom labels for x and y (important if the labels are custom but hidden!)
-    channels: {
-      xCustom: {
-        label: truncateLabel(xLabel),
-        // TODO: good for grouped bar charts, not good for other fx
-        value:
-          typeof xValue === "function"
-            ? xValue
-            : currentColumns.includes("fx")
-            ? "fx"
-            : "x",
-      },
-      yCustom: {
-        label: truncateLabel(yLabel),
-        value: typeof yValue === "function" ? yValue : "y",
-      },
-    },
-    ...tip,
     ...(type === "line" ? { stroke } : { fill }),
     ...(currentColumns.includes("x") ? { x: `x` } : {}),
     ...(sort ? sort : {}),

--- a/src/options/getTipMark.ts
+++ b/src/options/getTipMark.ts
@@ -1,4 +1,4 @@
-import { MarkOptions } from "@observablehq/plot";
+import { MarkOptions, TipOptions } from "@observablehq/plot";
 import { DuckPlot } from "..";
 import { borderOptions } from "../helpers";
 import * as Plot from "@observablehq/plot";
@@ -6,28 +6,15 @@ import * as Plot from "@observablehq/plot";
 // Get options for a specific mark (e.g., the line or area marks)
 export function getTipMark(instance: DuckPlot) {
   const plotOptions = instance.derivePlotOptions();
+  const type = instance.mark().type;
   const xLabel = instance.config().tipLabels?.x ?? plotOptions.x?.label ?? "",
     yLabel = instance.config().tipLabels?.y ?? plotOptions.y?.label ?? "",
     xValue = instance.config().tipValues?.x,
     yValue = instance.config().tipValues?.y;
   const data = instance.filteredData ?? instance.data();
   const currentColumns = Object.keys(data.types || {});
+  const fx = currentColumns.includes("fx") ? "fx" : undefined;
 
-  const tip = {
-    tip: {
-      stroke: borderOptions.borderColor,
-      format: {
-        xCustom: true,
-        yCustom: true,
-        x: false,
-        y: false,
-        color: true,
-        fy: false,
-        fx: false,
-        z: false, // Hide the auto generated "series" for area charts
-      },
-    },
-  };
   const ellipsis = "…";
   function truncateLabel(label: string | undefined, length: number = 25) {
     if (!label || label.length < length) return label;
@@ -52,8 +39,41 @@ export function getTipMark(instance: DuckPlot) {
         value: typeof yValue === "function" ? yValue : "y",
       },
     },
-    ...tip,
-  } satisfies MarkOptions;
+    format: {
+      xCustom: true,
+      yCustom: true,
+      x: false,
+      y: false,
+      color: true,
+      fy: false,
+      fx: false,
+      z: false, // Hide the auto generated "series" for area charts
+    },
+    stroke: borderOptions.borderColor,
+    ...(currentColumns.includes("x") ? { x: `x` } : {}),
+    ...(currentColumns.includes("fy") ? { fy: "fy" } : {}),
+    ...(fx ? { fx: `fx` } : {}),
+    ...(currentColumns.includes("y") ? { y: `y` } : {}),
+    ...(currentColumns.includes("series")
+      ? {
+          [type === "line" ||
+          type?.startsWith("rule") ||
+          type?.startsWith("tick")
+            ? "stroke"
+            : "fill"]: `series`,
+        }
+      : {}),
+  } satisfies TipOptions;
+  console.log({ options });
+  // Explicitly stack the values for area and bar charts
+  const maybeStackedOptions =
+    type === "areaY" || type === "barY"
+      ? Plot.stackY(options)
+      : type === "barX"
+      ? Plot.stackX(options)
+      : options;
 
-  return Plot.tip(instance.data(), Plot.pointerX(options));
+  // User pointerY for barX charts
+  const pointer = type === "barX" ? Plot.pointerY : Plot.pointerX;
+  return Plot.tip(instance.filteredData, pointer(maybeStackedOptions));
 }

--- a/src/options/getTipMark.ts
+++ b/src/options/getTipMark.ts
@@ -1,0 +1,59 @@
+import { MarkOptions } from "@observablehq/plot";
+import { DuckPlot } from "..";
+import { borderOptions } from "../helpers";
+import * as Plot from "@observablehq/plot";
+
+// Get options for a specific mark (e.g., the line or area marks)
+export function getTipMark(instance: DuckPlot) {
+  const plotOptions = instance.derivePlotOptions();
+  const xLabel = instance.config().tipLabels?.x ?? plotOptions.x?.label ?? "",
+    yLabel = instance.config().tipLabels?.y ?? plotOptions.y?.label ?? "",
+    xValue = instance.config().tipValues?.x,
+    yValue = instance.config().tipValues?.y;
+  const data = instance.filteredData ?? instance.data();
+  const currentColumns = Object.keys(data.types || {});
+
+  const tip = {
+    tip: {
+      stroke: borderOptions.borderColor,
+      format: {
+        xCustom: true,
+        yCustom: true,
+        x: false,
+        y: false,
+        color: true,
+        fy: false,
+        fx: false,
+        z: false, // Hide the auto generated "series" for area charts
+      },
+    },
+  };
+  const ellipsis = "…";
+  function truncateLabel(label: string | undefined, length: number = 25) {
+    if (!label || label.length < length) return label;
+    return label.slice(0, length) + ellipsis;
+  }
+
+  const options = {
+    // Create custom labels for x and y (important if the labels are custom but hidden!)
+    channels: {
+      xCustom: {
+        label: truncateLabel(xLabel),
+        // TODO: good for grouped bar charts, not good for other fx
+        value:
+          typeof xValue === "function"
+            ? xValue
+            : currentColumns.includes("fx")
+            ? "fx"
+            : "x",
+      },
+      yCustom: {
+        label: truncateLabel(yLabel),
+        value: typeof yValue === "function" ? yValue : "y",
+      },
+    },
+    ...tip,
+  } satisfies MarkOptions;
+
+  return Plot.tip(instance.data(), Plot.pointerX(options));
+}

--- a/src/options/getTipMark.ts
+++ b/src/options/getTipMark.ts
@@ -64,7 +64,6 @@ export function getTipMark(instance: DuckPlot) {
         }
       : {}),
   } satisfies TipOptions;
-  console.log({ options });
   // Explicitly stack the values for area and bar charts
   const maybeStackedOptions =
     type === "areaY" || type === "barY"

--- a/test/getMarkOptions.test.ts
+++ b/test/getMarkOptions.test.ts
@@ -4,6 +4,8 @@ import { JSDOM } from "jsdom";
 import { describe, expect, it, vi } from "vitest";
 import { createDbServer } from "../examples/util/createDbServer.js";
 import { getPrimaryMarkOptions } from "../src/options/getPrimaryMarkOptions";
+import { getTipMark } from "../src/options/getTipMark.js";
+import { Indexable } from "../src/types.js";
 const jsdom = new JSDOM(`
 <!DOCTYPE html>
 <head>
@@ -56,17 +58,18 @@ describe("getMarkOptions", () => {
       .rawData([{ a: 1 }], { a: "string" })
       .fy("a")
       .mark("areaY");
-    const result = getPrimaryMarkOptions(plot);
-
-    expect(result).toHaveProperty("channels", {
-      xCustom: {
-        label: "Custom X Axis",
-        value: "x",
-      },
-      yCustom: {
-        label: "Custom Y Axis",
-        value: "y",
-      },
+    // Plot.tip returns an object with a channels property, but getting a type
+    // error without recasting
+    const result = getTipMark(plot) as Indexable;
+    expect(result.channels).toHaveProperty("xCustom", {
+      label: "Custom X Axis",
+      value: "x",
+      filter: null,
+    });
+    expect(result.channels).toHaveProperty("yCustom", {
+      label: "Custom Y Axis",
+      value: "y",
+      filter: null,
     });
   });
 });


### PR DESCRIPTION
Rather than add a tip property to the primary mark, this PR adds an explicit tip mark. In the (future) case of multiple primary marks (likely just for raw data), this prevents multiple tooltips from being displayed. For example: 
<img width="503" alt="Screenshot 2024-11-25 at 10 51 27 AM" src="https://github.com/user-attachments/assets/6e0563f2-0ff0-4cae-8e50-499560c95d3f">
