### PR TITLE
Remove unnecessary legend re-render

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export class DuckPlot {
     undefined;
   visibleSeries: string[] = [];
   filteredData: Data | undefined = undefined;
-  chartElement: HTMLElement | null = null;
+  chartContainer: HTMLElement | null = null;
   seriesDomain: number[] = [];
 
   constructor(

--- a/src/legend/legend.css
+++ b/src/legend/legend.css
@@ -20,10 +20,6 @@
 .dp-categories {
   display: flex;
   flex-wrap: nowrap;
-  user-select: none;
-  -webkit-user-select: none; /* Safari */
-  -moz-user-select: none; /* Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
 }
 
 .dp-category:not(:last-child) {
@@ -43,6 +39,10 @@
   gap: 2px;
   align-items: center;
   text-wrap: nowrap;
+  user-select: none;
+  -webkit-user-select: none; /* Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
 }
 
 /* Popover for extra categories */

--- a/src/legend/legendCategorical.ts
+++ b/src/legend/legendCategorical.ts
@@ -13,12 +13,13 @@ export async function legendCategorical(
     instance.plotObject?.scale("color")?.domain ?? []
   )?.map((d) => `${d}`);
 
-  // Set the visible series to all categories if it's empty
-  if (instance.visibleSeries.length === 0) {
-    instance.visibleSeries = categories;
+  function isActive(category: string): boolean {
+    return (
+      instance.visibleSeries.length === 0 ||
+      instance.visibleSeries.includes(category)
+    );
   }
 
-  const visibleCategories = instance.visibleSeries;
   const colors = Array.from(instance.plotObject?.scale("color")?.range ?? []);
   const options = await instance.derivePlotOptions();
   const width = options.width || 500;
@@ -53,7 +54,7 @@ export async function legendCategorical(
   categories.forEach((category, i) => {
     const categoryDiv = document.createElement("div");
     categoryDiv.className = `dp-category${
-      visibleCategories.includes(category) ? "" : " dp-inactive"
+      isActive(category) ? "" : " dp-inactive"
     }`;
 
     const square = document.createElement("div");
@@ -104,25 +105,34 @@ export async function legendCategorical(
         // Shift-click: hide all others
         if (mouseEvent.shiftKey) {
           // If this is the only visible element, reset all to visible
-          if (
-            instance.visibleSeries.length === 1 &&
-            instance.visibleSeries.includes(elementId)
-          ) {
-            instance.visibleSeries = categories;
+          if (instance.visibleSeries.length === 1 && isActive(elementId)) {
+            instance.visibleSeries = [];
           } else {
             instance.visibleSeries = [elementId]; // show only this one
           }
         } else {
           // Regular click: toggle visibility of the clicked element
-          if (instance.visibleSeries.includes(elementId)) {
-            instance.visibleSeries = instance.visibleSeries.filter(
+          if (isActive(elementId)) {
+            const currentSeries = instance.visibleSeries.length
+              ? instance.visibleSeries
+              : categories;
+            instance.visibleSeries = currentSeries.filter(
               (id) => id !== elementId
             ); // Hide the clicked element
           } else {
             instance.visibleSeries.push(elementId); // Show the clicked element
           }
         }
-        instance.render();
+        // Update the active state of the items in the legend
+        legendElements.forEach((e) => {
+          if (isActive(`${e.textContent}`)) {
+            e.classList.remove("dp-inactive");
+          } else {
+            e.classList.add("dp-inactive");
+          }
+        });
+        // Rerender the plot, but not the legend itself
+        instance.render(false);
       });
     });
   }


### PR DESCRIPTION
Previously, updating the categorical legend re-rendered both the chart and the legend. This PR handles the active state of the legend items within the legend itself, rather than causing a full re-render. One benefit of this is that you can now keep the overflow menu open and toggle item visibility:
https://github.com/user-attachments/assets/55cae2f7-b03e-4834-b821-79d3d2a6dc3f

