### PR TITLE
Fix legend rendering on the server 

### DIFF
--- a/src/legend/legendCategorical.ts
+++ b/src/legend/legendCategorical.ts
@@ -68,7 +68,7 @@ export async function legendCategorical(
     }`;
 
     const symbolType = symbols[i];
-    const symbol = drawSymbol(symbolType, colors[i % colors.length]);
+    const symbol = drawSymbol(symbolType, colors[i % colors.length], document);
     categoryDiv.appendChild(symbol);
 
     const textNode = document.createTextNode(category);
@@ -81,9 +81,6 @@ export async function legendCategorical(
   // Hold collapsed categories
   const collapsedCategoriesDiv = document.createElement("div");
   collapsedCategoriesDiv.className = "dp-collapsed-categories";
-  collapsedCategoriesDiv.addEventListener("click", () =>
-    showPopover(container, height)
-  );
 
   const popoverDiv = document.createElement("div");
   popoverDiv.className = "dp-popover";
@@ -97,9 +94,11 @@ export async function legendCategorical(
   updateLegendDisplay(container, font);
   hiddenContainer.remove();
   legend.appendChild(container);
-
-  // Apply click event
-  if (instance.config().interactiveLegend !== false) {
+  // Apply click event listeners
+  if (instance.config().interactiveLegend !== false && !instance.isServer) {
+    collapsedCategoriesDiv.addEventListener("click", () =>
+      showPopover(container, height)
+    );
     const legendElements = legend.querySelectorAll<HTMLElement>(".dp-category");
 
     legendElements.forEach((element: SVGElement | HTMLElement) => {
@@ -218,7 +217,11 @@ function showPopover(container: HTMLDivElement, height: number): void {
     popover.style.overflowY = `auto`;
   }
 }
-function drawSymbol(symbolType: ChartType, color: string): HTMLElement {
+function drawSymbol(
+  symbolType: ChartType,
+  color: string,
+  document: Document
+): HTMLElement {
   const symbol = document.createElement("div");
   symbol.style.backgroundColor = color;
   symbol.style.width = "12px";

--- a/src/legend/legendContinuous.ts
+++ b/src/legend/legendContinuous.ts
@@ -8,7 +8,7 @@ export async function legendContinuous(
   const color = instance.plotObject?.scale("color");
   const document = instance.document;
   const onBrush =
-    instance.config().interactiveLegend === false
+    instance.config().interactiveLegend === false || instance.isServer
       ? null
       : (event: number[]) => {
           instance.seriesDomain = event;
@@ -19,7 +19,10 @@ export async function legendContinuous(
   const container = document.createElement("div");
   container.style.position = "relative";
   container.style.width = "300px";
-  const plotLegend = Plot.legend({ color }) as HTMLDivElement & Plot.Plot;
+  const plotLegend = Plot.legend({
+    color,
+    ...(instance.isServer ? { document: instance.document } : {}),
+  }) as HTMLDivElement & Plot.Plot;
   container.appendChild(plotLegend);
 
   if (onBrush !== null) {


### PR DESCRIPTION
Legend rendering was broken on the server for both continuous and categorical legends. In both cases, there was a similar cause (applying a click event to elements on the server, or referencing `document` when it was undefined). 