### PR TITLE
Fix binning for months

### DIFF
--- a/src/options/getInterval.ts
+++ b/src/options/getInterval.ts
@@ -34,8 +34,6 @@ export function computeInterval(data: Data, column: string = "x") {
 
   // Find the minimum difference
   const minDifference = min(differences) ?? 0; // Handle potential undefined
-  const dayLimit = 7 * 24 * 60 * 60 * 1000;
-  const weekLimit = 3 * 30 * 24 * 60 * 60 * 1000;
 
   const second = 1000;
   const minute = 60 * second;
@@ -48,7 +46,6 @@ export function computeInterval(data: Data, column: string = "x") {
   const decade = 10 * year;
   const century = 100 * year;
 
-  console.log({ minDifference, dayLimit });
   // Map minDifference to a D3 time interval
   if (minDifference < second) {
     return utcMillisecond; // Sub-second intervals

--- a/src/options/getInterval.ts
+++ b/src/options/getInterval.ts
@@ -34,32 +34,43 @@ export function computeInterval(data: Data, column: string = "x") {
 
   // Find the minimum difference
   const minDifference = min(differences) ?? 0; // Handle potential undefined
+  const dayLimit = 7 * 24 * 60 * 60 * 1000;
+  const weekLimit = 3 * 30 * 24 * 60 * 60 * 1000;
 
+  const second = 1000;
+  const minute = 60 * second;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+  const month = 4 * week;
+  const quarter = month * 3;
+  const year = 365 * day;
+  const decade = 10 * year;
+  const century = 100 * year;
+
+  console.log({ minDifference, dayLimit });
   // Map minDifference to a D3 time interval
-  if (minDifference < 1000) {
+  if (minDifference < second) {
     return utcMillisecond; // Sub-second intervals
-  } else if (minDifference < 60 * 1000) {
+  } else if (minDifference < minute) {
     return utcSecond; // Seconds
-  } else if (minDifference < 60 * 60 * 1000) {
+  } else if (minDifference < hour) {
     return utcMinute; // Minutes
-  } else if (minDifference < 24 * 60 * 60 * 1000) {
+  } else if (minDifference < day) {
     return utcHour; // Hours
-  } else if (minDifference < 7 * 24 * 60 * 60 * 1000) {
+  } else if (minDifference < week) {
     return utcDay; // Days
-  } else if (minDifference < 30 * 24 * 60 * 60 * 1000) {
+  } else if (minDifference < month) {
     return utcWeek; // Weeks
-  } else if (minDifference < 3 * 30 * 24 * 60 * 60 * 1000) {
+  } else if (minDifference < quarter) {
     return utcMonth; // Months
-  } else if (minDifference < 365 * 24 * 60 * 60 * 1000) {
-    // Approximate 1 quarter as 3 months
+  } else if (minDifference < year) {
     return utcMonth.every(3); // Quarters
-  } else if (minDifference < 10 * 365 * 24 * 60 * 60 * 1000) {
+  } else if (minDifference < decade) {
     return utcYear; // Years
-  } else if (minDifference < 100 * 365 * 24 * 60 * 60 * 1000) {
-    // Approximate 1 decade as 10 years
+  } else if (minDifference < century) {
     return utcYear.every(10); // Decades
   } else {
-    // Approximate 1 century as 100 years
     return utcYear.every(100); // Centuries
   }
 }


### PR DESCRIPTION
Previously, a month was set to 30 days, which obviously doesn't handle February 🤦 . So, this shortens a month bin to 4 weeks, and also adds time variables to make the code more legible. 
**Before**
<img width="542" alt="Screenshot 2024-12-20 at 9 45 15 AM" src="https://github.com/user-attachments/assets/f4012f4b-fa99-4a65-a3ab-d423fb1b6a3c" />

**After**
<img width="553" alt="Screenshot 2024-12-20 at 9 44 52 AM" src="https://github.com/user-attachments/assets/8d2fca30-37f5-4bf8-a52f-9a1093e2919a" />
