### PR TITLE
Remove missing data from circle pack

### DIFF
--- a/src/options/prepareCirclePackData.ts
+++ b/src/options/prepareCirclePackData.ts
@@ -14,7 +14,10 @@ export function prepareCirclePackData(
   // Group data by series
   const total = sum(data, (d) => d.y || 0);
   const groupedData = Array.from(
-    group(data, (d) => d.series || d.text || false),
+    group(
+      data.filter((d) => d.y),
+      (d) => d.series || d.text || false
+    ),
     ([key, values]) => ({
       name: key,
       children: values.map((v) => ({


### PR DESCRIPTION
If a value is 0 or missing, it should not be displayed in a circle pack. This filters those out to avoid drawing empty circles. 

**Before**
<img width="520" alt="Screenshot 2024-12-20 at 9 58 52 AM" src="https://github.com/user-attachments/assets/c3de85fa-7a2e-4a4f-9150-1f91714e88bb" />

**After**
<img width="559" alt="Screenshot 2024-12-20 at 9 59 16 AM" src="https://github.com/user-attachments/assets/28274e14-0ef6-467e-8e96-e5983a2ad079" />
