### PR TITLE
Enable custom click events

### DIFF
--- a/examples/index.client.js
+++ b/examples/index.client.js
@@ -45,6 +45,7 @@ async function renderPlots() {
       // Wrapper for charts and code
       const wrapper = document.createElement("div");
       wrapper.style.display = "flex";
+      wrapper.style.position = "relative";
       const label = document.createElement("h2");
       label.innerHTML = name;
       label.style.fontWeight = "normal";

--- a/examples/plots/index.js
+++ b/examples/plots/index.js
@@ -22,6 +22,7 @@ export * from "./multiY.js";
 export * from "./multiYReordered.js";
 export * from "./multiYandSeries.js";
 export * from "./options.js";
+export * from "./onClick.js";
 export * from "./partialChart.js";
 export * from "./partialChartContinuousColor.js";
 export * from "./partialChartX.js";

--- a/examples/plots/onClick.js
+++ b/examples/plots/onClick.js
@@ -1,6 +1,7 @@
 import { renderPlot } from "../util/renderPlotClient.js";
 // This code is both displayed in the browser and executed
 const onClick = (event, value) => {
+  console.log({ event, value });
   const div = document.createElement("div");
   div.style.position = "absolute";
   div.style.top = `${value.scaled.y}px`;

--- a/examples/plots/onClick.js
+++ b/examples/plots/onClick.js
@@ -3,19 +3,16 @@ import { renderPlot } from "../util/renderPlotClient.js";
 const onClick = (event, value) => {
   console.log({ event, value });
   const div = document.createElement("div");
-  div.style.position = "absolute";
-  div.style.top = `${value.scaled.y}px`;
-  div.style.left = `${value.scaled.x}px`;
   event.srcElement.parentNode.appendChild(
     div
-  ).innerText = `You clicked at ${value.scaled.y}`;
-  // .innerText = `You clicked at ${JSON.stringify(value)}`;
+  ).innerText = `You clicked on ${JSON.stringify(value)}`;
 };
 const codeString = `
 duckplot
   .table("stocks")
   .x("Date")
   .y("Close")
+  .color("Symbol")
   .fy("Symbol")    
   .mark("line")
   .options({ height: 300})

--- a/examples/plots/onClick.js
+++ b/examples/plots/onClick.js
@@ -1,0 +1,20 @@
+import { renderPlot } from "../util/renderPlotClient.js";
+// This code is both displayed in the browser and executed
+const onClick = (event, value) => {
+  event.srcElement.parentNode.appendChild(
+    document.createElement("div")
+  ).innerText = `You clicked at ${JSON.stringify(value)}`;
+};
+const codeString = `
+duckplot
+  .table("stocks")
+  .x("Date")
+  .y("Close")
+  .fy("Symbol")    
+  .mark("line")
+  .options({ height: 300})
+  .config({onClick})
+`;
+
+export const onclick = (options) =>
+  renderPlot("stocks.csv", codeString, options, onClick);

--- a/examples/plots/onClick.js
+++ b/examples/plots/onClick.js
@@ -1,9 +1,14 @@
 import { renderPlot } from "../util/renderPlotClient.js";
 // This code is both displayed in the browser and executed
 const onClick = (event, value) => {
+  const div = document.createElement("div");
+  div.style.position = "absolute";
+  div.style.top = `${value.scaled.y}px`;
+  div.style.left = `${value.scaled.x}px`;
   event.srcElement.parentNode.appendChild(
-    document.createElement("div")
-  ).innerText = `You clicked at ${JSON.stringify(value)}`;
+    div
+  ).innerText = `You clicked at ${value.scaled.y}`;
+  // .innerText = `You clicked at ${JSON.stringify(value)}`;
 };
 const codeString = `
 duckplot

--- a/examples/util/renderPlotClient.js
+++ b/examples/util/renderPlotClient.js
@@ -12,7 +12,12 @@ if (typeof window !== "undefined") {
   // Server-side
   DuckPlot = (await import("../../dist/index.cjs")).DuckPlot;
 }
-export async function renderPlot(fileName, codeString, constructorOptions) {
+export async function renderPlot(
+  fileName,
+  codeString,
+  constructorOptions,
+  onClick
+) {
   try {
     const db = await createDb(fileName);
     const duckplot = constructorOptions
@@ -23,8 +28,9 @@ export async function renderPlot(fileName, codeString, constructorOptions) {
       "db",
       "Plot",
       "d3",
+      "onClick",
       codeString
-    )(duckplot, db, Plot, d3);
+    )(duckplot, db, Plot, d3, onClick);
     const plot = await duckplot.render();
     return [plot, codeString];
   } catch (error) {

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -30,6 +30,25 @@ export async function render(
     ? PlotAutoMargin(plotOptions, {}, instance.font)
     : Plot.plot(plotOptions);
 
+  // Keep track of the hovered element for click events!
+  if (instance.config().onClick && !instance.isServer) {
+    instance.plotObject.addEventListener(
+      "pointerdown",
+      (event) => {
+        event.stopPropagation();
+        instance.config().onClick!(event, instance.plotObject?.value);
+        // Force a pointerleave to hide the tooltip
+        // see https://github.com/observablehq/plot/issues/1832
+        const pointerleave = new PointerEvent("pointerleave", {
+          bubbles: true,
+          pointerType: "mouse",
+        });
+        event.target?.dispatchEvent(pointerleave);
+      },
+      { capture: true }
+    );
+  }
+
   instance.plotObject.setAttribute("xmlns", "http://www.w3.org/2000/svg");
   instance.plotObject.classList.add("plot-object");
 

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -32,43 +32,43 @@ export async function render(
 
   // Keep track of the hovered element for click events!
   if (instance.config().onClick && !instance.isServer) {
-    function svgToPixel(svgElement: SVGSVGElement, x: number, y: number) {
-      const viewBox = svgElement.viewBox.baseVal;
-      const renderedWidth = svgElement.clientWidth;
-      const renderedHeight = svgElement.clientHeight;
+    // function svgToPixel(svgElement: SVGSVGElement, x: number, y: number) {
+    //   const viewBox = svgElement.viewBox.baseVal;
+    //   const renderedWidth = svgElement.clientWidth;
+    //   const renderedHeight = svgElement.clientHeight;
 
-      const scaleX = renderedWidth / viewBox.width;
-      const scaleY = renderedHeight / viewBox.height;
+    //   const scaleX = renderedWidth / viewBox.width;
+    //   const scaleY = renderedHeight / viewBox.height;
 
-      const pixelX = (x - viewBox.x) * scaleX;
-      const pixelY = (y - viewBox.y) * scaleY;
+    //   const pixelX = (x - viewBox.x) * scaleX;
+    //   const pixelY = (y - viewBox.y) * scaleY;
 
-      return { x: pixelX, y: pixelY };
-    }
+    //   return { x: pixelX, y: pixelY };
+    // }
     instance.plotObject.addEventListener(
       "pointerdown",
       (event) => {
         event.stopPropagation();
         const raw = instance.plotObject?.value;
         // Scale the point to the svg's coordinates
-        const scaledRaw = {
-          x:
-            instance.plotObject?.scale("x")?.apply(raw.x) +
-            (instance.plotObject?.scale("fx")?.apply(raw.fx) || 0),
-          y:
-            instance.plotObject?.scale("y")?.apply(raw.y) +
-            (instance.plotObject?.scale("fy")?.apply(raw.fy) || 0) -
-            10, // for font height,
-        };
+        // const scaled = {
+        //   x:
+        //     instance.plotObject?.scale("x")?.apply(raw.x) +
+        //     (instance.plotObject?.scale("fx")?.apply(raw.fx) || 0),
+        //   y:
+        //     instance.plotObject?.scale("y")?.apply(raw.y) +
+        //     (instance.plotObject?.scale("fy")?.apply(raw.fy) || 0) -
+        //     10, // for font height,
+        // };
 
-        // Convert the scaled point to pixel coordinates
-        const scaled = svgToPixel(
-          instance.plotObject as SVGSVGElement,
-          scaledRaw.x,
-          scaledRaw.y
-        );
+        // // Convert the scaled point to pixel coordinates
+        // const scaled = svgToPixel(
+        //   instance.plotObject as SVGSVGElement,
+        //   scaledRaw.x,
+        //   scaledRaw.y
+        // );
 
-        instance.config().onClick!(event, { raw, scaled });
+        instance.config().onClick!(event, { ...raw });
         // Force a pointerleave to hide the tooltip
         // see https://github.com/observablehq/plot/issues/1832
         const pointerleave = new PointerEvent("pointerleave", {

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -36,7 +36,18 @@ export async function render(
       "pointerdown",
       (event) => {
         event.stopPropagation();
-        instance.config().onClick!(event, instance.plotObject?.value);
+        const raw = instance.plotObject?.value;
+        const scaled = {
+          x:
+            instance.plotObject?.scale("x")?.apply(raw.x) +
+            (instance.plotObject?.scale("fx")?.apply(raw.fx) || 0),
+          y:
+            instance.plotObject?.scale("y")?.apply(raw.y) +
+            (instance.plotObject?.scale("fy")?.apply(raw.fy) || 0) -
+            10, // for font height,
+        };
+
+        instance.config().onClick!(event, { raw, scaled });
         // Force a pointerleave to hide the tooltip
         // see https://github.com/observablehq/plot/issues/1832
         const pointerleave = new PointerEvent("pointerleave", {

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -32,43 +32,13 @@ export async function render(
 
   // Keep track of the hovered element for click events!
   if (instance.config().onClick && !instance.isServer) {
-    // function svgToPixel(svgElement: SVGSVGElement, x: number, y: number) {
-    //   const viewBox = svgElement.viewBox.baseVal;
-    //   const renderedWidth = svgElement.clientWidth;
-    //   const renderedHeight = svgElement.clientHeight;
-
-    //   const scaleX = renderedWidth / viewBox.width;
-    //   const scaleY = renderedHeight / viewBox.height;
-
-    //   const pixelX = (x - viewBox.x) * scaleX;
-    //   const pixelY = (y - viewBox.y) * scaleY;
-
-    //   return { x: pixelX, y: pixelY };
-    // }
     instance.plotObject.addEventListener(
       "pointerdown",
       (event) => {
         event.stopPropagation();
-        const raw = instance.plotObject?.value;
-        // Scale the point to the svg's coordinates
-        // const scaled = {
-        //   x:
-        //     instance.plotObject?.scale("x")?.apply(raw.x) +
-        //     (instance.plotObject?.scale("fx")?.apply(raw.fx) || 0),
-        //   y:
-        //     instance.plotObject?.scale("y")?.apply(raw.y) +
-        //     (instance.plotObject?.scale("fy")?.apply(raw.fy) || 0) -
-        //     10, // for font height,
-        // };
+        // Do onclick event
+        instance.config().onClick!(event, { ...instance.plotObject?.value });
 
-        // // Convert the scaled point to pixel coordinates
-        // const scaled = svgToPixel(
-        //   instance.plotObject as SVGSVGElement,
-        //   scaledRaw.x,
-        //   scaledRaw.y
-        // );
-
-        instance.config().onClick!(event, { ...raw });
         // Force a pointerleave to hide the tooltip
         // see https://github.com/observablehq/plot/issues/1832
         const pointerleave = new PointerEvent("pointerleave", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,7 @@ export type Config = {
   aggregate?: Aggregate;
   interactiveLegend?: boolean;
   percent?: boolean; // for percent stacked charts, TODO document clearly
+  onClick?: (event: Event, value: unknown) => void;
 };
 
 export type Aggregate =


### PR DESCRIPTION
Users can now pass an `onClick` parameter to `.config()` to pass in a click event. The event emits:

```js
(event, { ...instance.plotObject?.value })
```

And also forces a `pointerLeave` event to close the tooltip, see https://github.com/observablehq/plot/issues/1832