### PR TITLE
Enable options for markColumn

### DIFF
--- a/examples/plots/rawDataMultiChart.js
+++ b/examples/plots/rawDataMultiChart.js
@@ -19,7 +19,7 @@ duckplot
   .x("col1")
   .y("col2")
   .color("col3")
-  .markColumn("mark")
+  .markColumn("mark", {dot: {r: 10}, barY: {opacity: .2}})
 `;
 
 export const rawDataMultiChart = (options) =>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -168,7 +168,7 @@ export function processRawData(instance: DuckPlot): Data {
     { key: "fx", column: instance.fx().column },
     { key: "r", column: instance.r().column },
     { key: "text", column: instance.text().column },
-    { key: "markColumn", column: instance.markColumn() },
+    { key: "markColumn", column: instance.markColumn().column },
   ];
 
   // Map over raw data to extract chart data based on defined columns
@@ -230,7 +230,7 @@ export const checkForConfigErrors = (instance: DuckPlot) => {
   if (!instance.ddb) throw new Error("Database not set");
   if (!instance.table()) throw new Error("Table not set");
   const type = instance.mark().type;
-  if (!type && !instance.markColumn())
+  if (!type && !instance.markColumn().column)
     throw new Error("Mark type or mark column not set");
   const multipleX =
     Array.isArray(instance.x().column) && instance.x().column.length > 1;
@@ -259,8 +259,8 @@ export const checkForConfigErrors = (instance: DuckPlot) => {
   }
 
   // Using rawData and/or markColumn checks
-  if (instance.markColumn() && instance.rawData().length === 0)
+  if (instance.markColumn().column && instance.rawData().length === 0)
     throw new Error("You must supply rawData to use markColumn");
-  if (instance.markColumn() && instance.mark())
+  if (instance.markColumn().column && instance.mark())
     throw new Error("You cannot use both a markColumn and a mark type");
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
   PlotProperty,
   QueryMap,
   Sorts,
+  MarkColumnProperty,
 } from "./types";
 const emptyProp = { column: "", options: {} };
 export class DuckPlot {
@@ -45,7 +46,7 @@ export class DuckPlot {
   private _newDataProps: boolean = true;
   private _data: Data = [];
   private _rawData: Data = [];
-  private _markColumn: string | undefined = undefined;
+  private _markColumn: MarkColumnProperty = {};
   private _config: Config = {};
   private _query: string = "";
   private _description: string = ""; // TODO: add tests
@@ -239,12 +240,20 @@ export class DuckPlot {
 
   // Mark column- only used with rawData, and the column holds the mark for each
   // row (e.g., "line", "areaY", etc.)
-  markColumn(): string | undefined;
-  markColumn(column: string): this;
-  markColumn(column?: string): DuckPlot | string | undefined {
-    if (!column) return this._markColumn;
-    this._markColumn = column;
-    return this;
+  markColumn(): MarkColumnProperty;
+  markColumn(column: string, options?: MarkColumnProperty["options"]): this;
+  markColumn(
+    column?: string,
+    options?: MarkColumnProperty["options"]
+  ): MarkColumnProperty | this {
+    if (column) {
+      if (this._markColumn.column !== column) {
+        this._newDataProps = true; // when changed, we need to requery the data
+      }
+      this._markColumn = { column, ...(options ? { options } : {}) };
+      return this;
+    }
+    return this._markColumn!;
   }
 
   // Prepare data for rendering

--- a/src/legend/legendCategorical.ts
+++ b/src/legend/legendCategorical.ts
@@ -16,7 +16,7 @@ export async function legendCategorical(
 
   // Get the symbols for each category
   const symbols = categories.map((category) => {
-    if (!instance.markColumn()) return instance.mark().type;
+    if (!instance.markColumn().column) return instance.mark().type;
     const data = instance.data();
     // == as this has been stringified above
     const symbol = data.find((d) => d.series == category)?.markColumn;

--- a/src/options/getAllMarkOptions.ts
+++ b/src/options/getAllMarkOptions.ts
@@ -68,7 +68,7 @@ export function getAllMarkOptions(instance: DuckPlot) {
 
   // Assume that if someone has specified a markcolumn, they want to show it
   const marks: ChartType[] =
-    markColumnMarks.length > 0 && instance.markColumn() !== undefined
+    markColumnMarks.length > 0 && instance.markColumn().column !== undefined
       ? markColumnMarks
       : [mark!];
 

--- a/src/options/getPrimaryMarkOptions.ts
+++ b/src/options/getPrimaryMarkOptions.ts
@@ -15,7 +15,9 @@ export function getPrimaryMarkOptions(
   const type = markType ?? instance.mark().type; // pass in a markType for mulitple marks
   const data = instance.filteredData ?? instance.data();
   const currentColumns = Object.keys(data.types || {});
-  const userOptions = instance.mark().options;
+  const userOptions = markType
+    ? instance.markColumn().options?.[markType]
+    : instance.mark().options;
   const color = isColor(instance.color()?.column)
     ? instance.color()?.column
     : defaultColors[0];

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,15 @@ export type MarkProperty = {
   options?: AllMarkOptions;
 };
 
+// Remove `undefined` from the chart type keys for type below
+type DefinedChartType = Exclude<ChartType, undefined>;
+
+// The options are key-value pairs so they're specific to each mark type
+export type MarkColumnProperty = {
+  column?: string;
+  options?: Partial<Record<DefinedChartType, AllMarkOptions>>;
+};
+
 // A few types that we can't quite squeeze into (or out of) PlotOptions. The
 // label display options are important because the labels specifcy the labels
 // in the tooltips (but someone might want to turn off the labels in the plot)


### PR DESCRIPTION
The `.markColumn()` call now supports a second `options` argument (akin to how the `.mark()` method allows you to pass in mark options for a single mark). Because you may want to pass in _different_ options for each mark, the expected shape is an object where the keys are mark-types and the values are the options for the mark. 

For example: 

```js
duckplot
  .rawData(rawData, types)
  .x("col1")
  .y("col2")
  .color("col3")
  .markColumn("mark", {dot: {r: 10}, barY: {opacity: .2}})
```