### PR TITLE
Expose transformed table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@observablehq/plot": "0.6.16",
+        "@paralleldrive/cuid2": "^2.2.2",
         "d3": "7.9.0",
         "d3-array": "3.2.4",
         "fast-deep-equal": "3.1.3"
@@ -950,6 +951,18 @@
         "resolve": "~1.22.2"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@observablehq/plot": {
       "version": "0.6.16",
       "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.16.tgz",
@@ -961,6 +974,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "@observablehq/plot": "0.6.16",
+    "@paralleldrive/cuid2": "^2.2.2",
     "d3": "7.9.0",
     "d3-array": "3.2.4",
     "fast-deep-equal": "3.1.3"

--- a/src/data/prepareData.ts
+++ b/src/data/prepareData.ts
@@ -7,7 +7,7 @@ import {
 } from "../types";
 import {
   columnIsDefined,
-  getAggregateInfo,
+  getFinalQuery,
   getLabel,
   getTransformQuery,
 } from "./query";
@@ -140,17 +140,15 @@ export async function prepareData(
   const transformedTypes = await columnTypes(instance.ddb, reshapeTableName);
 
   // TODO: more clear arguments in here
-  const { labels: aggregateLabels, queryString: aggregateQuery } =
-    getAggregateInfo(
-      type,
-      columns,
-      [...transformedTypes.keys()],
-      reshapeTableName,
-      !shouldAggregate ? false : instance.config().aggregate,
-      description,
-      instance.config().percent
-    );
-  queryString = aggregateQuery;
+  const { labels: aggregateLabels, queryString: finalQuery } = getFinalQuery(
+    instance,
+    columns,
+    [...transformedTypes.keys()],
+    reshapeTableName,
+    !shouldAggregate ? false : instance.config().aggregate,
+    description
+  );
+  queryString = finalQuery;
 
   labels = aggregateLabels;
   let data;

--- a/src/data/prepareData.ts
+++ b/src/data/prepareData.ts
@@ -158,7 +158,7 @@ export async function prepareData(
   // separately select from
   await runQuery(instance.ddb, queryString);
   data = await runQuery(instance.ddb, `SELECT * FROM chart_${instance.id()}`);
-  schema = await runQuery(instance.ddb, `DESCRIBE ${reshapeTableName}`);
+  schema = await runQuery(instance.ddb, `DESCRIBE chart_${instance.id()}`);
   // Format data as an array of objects
   let formatted: Data = formatResults(data, schema);
 

--- a/src/data/prepareData.ts
+++ b/src/data/prepareData.ts
@@ -154,7 +154,10 @@ export async function prepareData(
   let data;
   let schema: DescribeSchema;
   queries["final"] = queryString;
-  data = await runQuery(instance.ddb, queryString);
+  // This query will *generate* the final table, which we then need to
+  // separately select from
+  await runQuery(instance.ddb, queryString);
+  data = await runQuery(instance.ddb, `SELECT * FROM chart_${instance.id()}`);
   schema = await runQuery(instance.ddb, `DESCRIBE ${reshapeTableName}`);
   // Format data as an array of objects
   let formatted: Data = formatResults(data, schema);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -145,10 +145,6 @@ const dateTypes: string[] = [
   "DATETIME",
 ];
 
-export function getUniqueId() {
-  return Date.now().toString(36) + Math.random().toString(36).substring(2);
-}
-
 export function processRawData(instance: DuckPlot): Data {
   const rawData = instance.rawData();
   if (!rawData || !rawData.types) return [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import * as Plot from "@observablehq/plot";
 import { prepareData } from "./data/prepareData";
 import { getLegendType, getSorts } from "./options/getPlotOptions";
-import { checkForConfigErrors, getUniqueId, processRawData } from "./helpers";
+import { checkForConfigErrors, processRawData } from "./helpers";
 import { derivePlotOptions } from "./options/derivePlotOptions";
+import { createId } from "@paralleldrive/cuid2";
 import { handleProperty } from "./handleProperty";
 import { getAllMarkOptions } from "./options/getAllMarkOptions";
 import { render } from "./render/render";
@@ -77,7 +78,7 @@ export class DuckPlot {
     this._document = this._isServer
       ? this._jsdom!.window.document
       : window?.document;
-    this._id = getUniqueId();
+    this._id = createId();
   }
 
   // Set the table to query against

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,11 +349,11 @@ export class DuckPlot {
   get jsdom(): any {
     return this._jsdom;
   }
-  get id(): string {
-    return this._id;
-  }
   get sorts(): Sorts {
     return this._sorts;
+  }
+  id(): string {
+    return this._id;
   }
   data(): Data {
     return this._data || [];

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -86,7 +86,7 @@ export async function render(
   const container =
     instance.chartContainer || instance.document.createElement("div");
   if (!instance.chartContainer) {
-    container.id = instance.id;
+    container.id = instance.id();
     instance.chartContainer = container;
   }
 


### PR DESCRIPTION
To support the case that a user wants to interact directly with the transformed data in the DuckDB instance, DuckPlot now creates or replaces a table with the final transformed values. The table is named `chart_${instance.id}`. This PR also:

-  Uses a more reliable unique ID generator `"@paralleldrive/cuid2` for creating table names (and SVG ids)
- Exposes the `.id()` method to users
- Renames and cleans up the `getAggregateInfo` function and updates corresponding tests.
