### PR TITLE
Fix legend spillover

### DIFF
--- a/src/legend/legendCategorical.ts
+++ b/src/legend/legendCategorical.ts
@@ -205,11 +205,11 @@ function updateLegendDisplay(container: HTMLDivElement, font: any): void {
     // update the text
     if (collapsedWidth + categoriesWidth > containerWidth) {
       const lastVisibleCategory = categoryDivs[visibleCount - 1];
-      lastVisibleCategory.style.display = "none"; // Hide the last visible category
+      lastVisibleCategory.style.borderRight = "none";
       collapsedCategories.textContent = `+${
         totalCategories - visibleCount + 1
       } more`;
-      collapsedCategories.appendChild(lastVisibleCategory); // Move it to the collapsed section
+      popover.appendChild(lastVisibleCategory); // Move it to the collapsed section
     }
   } else {
     collapsedCategories.style.display = "none";

--- a/src/legend/legendCategorical.ts
+++ b/src/legend/legendCategorical.ts
@@ -144,31 +144,34 @@ export async function legendCategorical(
   return legend;
 }
 
+// Measurement differes between server and client
+const getWidth = function (element: HTMLDivElement, font: any): number {
+  if (font && font.getAdvanceWidth) {
+    const width = font.getAdvanceWidth(element.textContent || "", 10) + 12 + 12;
+    return width;
+  } else {
+    const width = element.offsetWidth;
+    return width;
+  }
+};
+
 function updateLegendDisplay(container: HTMLDivElement, font: any): void {
-  // Measurement differes between server and client
-  const getWidth = function (element: HTMLDivElement): number {
-    if (font && font.getAdvanceWidth) {
-      const width =
-        font.getAdvanceWidth(element.textContent || "", 10) + 12 + 12;
-      return width;
-    } else {
-      const width = element.offsetWidth;
-      return width;
-    }
-  };
-  const categoriesDiv = container.querySelector(
+  // Select the category containers
+  const legendContainer = container.querySelector(
     ".dp-categories"
   ) as HTMLDivElement;
+
+  // Select the collapsed categories and popover
   const collapsedCategories = container.querySelector(
     ".dp-collapsed-categories"
   ) as HTMLDivElement;
   const popover = container.querySelector(".dp-popover") as HTMLDivElement;
 
   const containerWidth = +(container.style.maxWidth.replace("px", "") || 0);
-  let categoriesWidth = 0;
+  let categoriesWidth = 30; // Start with some padding
   let visibleCount = 0;
 
-  const categoryDivs = categoriesDiv.querySelectorAll(
+  const categoryDivs = legendContainer.querySelectorAll(
     ".dp-category"
   ) as NodeListOf<HTMLDivElement>;
   popover.innerHTML = ""; // Clear previous popover items
@@ -180,11 +183,9 @@ function updateLegendDisplay(container: HTMLDivElement, font: any): void {
 
   // Calculate how many categories can fit
   categoryDivs.forEach((category, i) => {
-    categoriesWidth += getWidth(category) + 10; // Adding gap
+    categoriesWidth += getWidth(category, font);
     if (categoriesWidth > containerWidth) {
-      // category.style.display = "none";
-
-      // Add to popover
+      // Move element to popover
       category.style.borderRight = "none";
       popover.appendChild(category);
     } else {
@@ -196,7 +197,20 @@ function updateLegendDisplay(container: HTMLDivElement, font: any): void {
   const totalCategories = categoryDivs.length;
   if (visibleCount < totalCategories) {
     collapsedCategories.style.display = "flex";
+    collapsedCategories.style.whiteSpace = "nowrap";
     collapsedCategories.textContent = `+${totalCategories - visibleCount} more`;
+    // Check to see if the collapsed category now exceeds the width
+    const collapsedWidth = getWidth(collapsedCategories, font);
+    // If it does, move the last visible category to the collapsed section and
+    // update the text
+    if (collapsedWidth + categoriesWidth > containerWidth) {
+      const lastVisibleCategory = categoryDivs[visibleCount - 1];
+      lastVisibleCategory.style.display = "none"; // Hide the last visible category
+      collapsedCategories.textContent = `+${
+        totalCategories - visibleCount + 1
+      } more`;
+      collapsedCategories.appendChild(lastVisibleCategory); // Move it to the collapsed section
+    }
   } else {
     collapsedCategories.style.display = "none";
   }

--- a/src/legend/legendContinuous.ts
+++ b/src/legend/legendContinuous.ts
@@ -18,18 +18,20 @@ export async function legendContinuous(
   // Create a div container
   const container = document.createElement("div");
   container.style.position = "relative";
-  container.style.width = "300px";
   const options = await instance.derivePlotOptions();
+  const maxWidth = 300;
+  const optionWidth = options.width || 0;
+  const width = optionWidth > maxWidth ? maxWidth : optionWidth;
   const label = options.color?.label ?? instance.data().labels?.series;
   const plotLegend = Plot.legend({
     color,
     label,
+    width,
     ...(instance.isServer ? { document: instance.document } : {}),
   }) as HTMLDivElement & Plot.Plot;
   container.appendChild(plotLegend);
 
   if (onBrush !== null) {
-    const width = 240;
     const height = 50;
     const svg = d3
       .select(container)


### PR DESCRIPTION
This fixes issues with both continuous and categorical legends exceeding their chart width. 

- **Categorical legends** were not taking into account the space occupied by the overflow category _+ N more_. As a result, it sometimes exceeded the boundaries (which could lead to the legend getting cut-off, depending on the container)
- **Continuous legends** had a fixed width of 240px, which was obviously not responsive. Now it fits within the same `width` as the chart

<img width="51" alt="Screenshot 2025-06-10 at 3 13 48 PM" src="https://github.com/user-attachments/assets/be56d56f-d58d-4ba7-b40e-a9f812d9e529" />
<br/>
<img width="289" alt="Screenshot 2025-06-10 at 3 15 08 PM" src="https://github.com/user-attachments/assets/dac36b11-e0bf-48a6-8436-7b7234d3fca6" />

