### PR TITLE
Add types export to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./style.css": {
       "default": "./dist/style.css"


### PR DESCRIPTION
When the cjs export was added (https://github.com/SummerForeverCo/duck-plot/pull/96), the location of the type was wasn't specified, leading to type errors. 