### PR TITLE
Compute interval for rectX marks

### DIFF
--- a/examples/plots/histogram.js
+++ b/examples/plots/histogram.js
@@ -1,0 +1,34 @@
+import { renderPlot } from "../util/renderPlotClient.js";
+// This code is both displayed in the browser and executed
+
+const codeString = `duckplot
+  .query(\`WITH stats AS (
+  SELECT
+    MIN("Open") AS min_open,
+    MAX("Open") AS max_open
+  FROM stocks
+),
+binned AS (
+  SELECT
+    stocks."Open",
+    stats.min_open,
+    stats.max_open,
+    (stats.max_open - stats.min_open) / 20.0 AS bin_width
+  FROM stocks, stats
+)
+SELECT
+  FLOOR(("Open" - min_open) / bin_width) AS bin,
+  COUNT(*) AS count,
+  ROUND(min_open + FLOOR(("Open" - min_open) / bin_width) * bin_width, 2) AS bin_start,
+  ROUND(min_open + (FLOOR(("Open" - min_open) / bin_width) + 1) * bin_width, 2) AS bin_end
+FROM binned
+GROUP BY bin, min_open, bin_width
+ORDER BY bin\`)
+  .table("stocks")
+  .x("bin_start")
+  .y("count")
+  .mark("rectY");
+`;
+
+export const histogram = (options) =>
+  renderPlot("stocks.csv", codeString, options);

--- a/examples/plots/histogramX.js
+++ b/examples/plots/histogramX.js
@@ -1,0 +1,34 @@
+import { renderPlot } from "../util/renderPlotClient.js";
+// This code is both displayed in the browser and executed
+
+const codeString = `duckplot
+  .query(\`WITH stats AS (
+  SELECT
+    MIN("Open") AS min_open,
+    MAX("Open") AS max_open
+  FROM stocks
+),
+binned AS (
+  SELECT
+    stocks."Open",
+    stats.min_open,
+    stats.max_open,
+    (stats.max_open - stats.min_open) / 20.0 AS bin_width
+  FROM stocks, stats
+)
+SELECT
+  FLOOR(("Open" - min_open) / bin_width) AS bin,
+  COUNT(*) AS count,
+  ROUND(min_open + FLOOR(("Open" - min_open) / bin_width) * bin_width, 2) AS bin_start,
+  ROUND(min_open + (FLOOR(("Open" - min_open) / bin_width) + 1) * bin_width, 2) AS bin_end
+FROM binned
+GROUP BY bin, min_open, bin_width
+ORDER BY bin\`)
+  .table("stocks")
+  .x("count")
+  .y("bin_start")
+  .mark("rectX");
+`;
+
+export const histogramX = (options) =>
+  renderPlot("stocks.csv", codeString, options);

--- a/examples/plots/index.js
+++ b/examples/plots/index.js
@@ -17,6 +17,8 @@ export * from "./groupedBarMultiY.js";
 export * from "./groupedBarMultiYReorder.js";
 export * from "./groupedBarSeries.js";
 export * from "./groupedBarSeriesAndY.js";
+export * from "./histogram.js";
+export * from "./histogramX.js";
 export * from "./horizontalAverage.js";
 export * from "./implicitAggregation.js";
 export * from "./line.js";

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -187,7 +187,6 @@ export function getTransformQuery(
     description.value += `The columns ${formatColumnString(
       transformColumns
     )} were unpivoted, creating colors for each series.\n`;
-    console.log({ description });
     return getUnpivotQuery(type, config, tableName, intoTable);
   } else {
     return getStandardTransformQuery(type, config, tableName, intoTable);

--- a/src/options/getInterval.ts
+++ b/src/options/getInterval.ts
@@ -14,12 +14,18 @@ import { min, pairs } from "d3-array";
 
 import { Data } from "../types";
 
-export function computeInterval(data: Data, column: string = "x") {
-  // Handle empty data
-  if (data.length === 0) {
-    return undefined;
-  }
+export function computeInterval(
+  data: Data,
+  column: string = "x",
+  isDate: boolean = true
+): any {
+  if (data.length === 0) return undefined;
+  return isDate
+    ? computeDateInterval(data, column)
+    : computeNumericInterval(data, column);
+}
 
+export function computeDateInterval(data: Data, column: string = "x") {
   // Sort distinct values (assumes they are repeated for colors / faceting)
   const sortedData = Array.from(
     new Set(data.map((d) => +(d[column] as number)))
@@ -70,4 +76,19 @@ export function computeInterval(data: Data, column: string = "x") {
   } else {
     return utcYear.every(100); // Centuries
   }
+}
+
+export function computeNumericInterval(
+  data: Data,
+  column: string = "x"
+): number | undefined {
+  // Sort and deduplicate
+  const sorted = Array.from(
+    new Set(data.map((d) => +(d[column] as number)))
+  ).sort((a, b) => a - b);
+
+  if (sorted.length < 2) return undefined;
+
+  const differences = pairs(sorted).map(([a, b]) => b - a);
+  return min(differences);
 }

--- a/src/options/getPrimaryMarkOptions.ts
+++ b/src/options/getPrimaryMarkOptions.ts
@@ -3,7 +3,7 @@ import { DuckPlot } from "..";
 import { isColor } from "./getPlotOptions";
 import { defaultColors } from "../helpers";
 import { ChartType } from "../types";
-import { computeInterval, computeNumericInterval } from "./getInterval";
+import { computeInterval } from "./getInterval";
 
 // Get options for a specific mark (e.g., the line or area marks)
 export function getPrimaryMarkOptions(

--- a/src/options/getPrimaryMarkOptions.ts
+++ b/src/options/getPrimaryMarkOptions.ts
@@ -3,7 +3,7 @@ import { DuckPlot } from "..";
 import { isColor } from "./getPlotOptions";
 import { defaultColors } from "../helpers";
 import { ChartType } from "../types";
-import { computeInterval } from "./getInterval";
+import { computeInterval, computeNumericInterval } from "./getInterval";
 
 // Get options for a specific mark (e.g., the line or area marks)
 export function getPrimaryMarkOptions(
@@ -33,14 +33,20 @@ export function getPrimaryMarkOptions(
       ? { sort: (d: any) => d.x }
       : {};
 
-  // If this is a rect mark with a date value axis, compute the interval
+  // Compute interval for rect marks with a continuous axis (avoid Plot's default binning)
   let interval;
+  const isRectYWithContinuousX =
+    markType === "rectY" && ["date", "number"].includes(types?.x || "");
+  const isRectXWithContinuousY =
+    markType === "rectX" && ["date", "number"].includes(types?.y || "");
+
   if (
-    ((markType === "rectY" && types?.x === "date") ||
-      (markType === "rectX" && types?.y === "date")) &&
-    userOptions?.interval === undefined // Note, there's no way to just say "no default"
+    (isRectYWithContinuousX || isRectXWithContinuousY) &&
+    userOptions?.interval === undefined
   ) {
-    interval = computeInterval(data, markType === "rectY" ? "x" : "y");
+    const axis = markType === "rectY" ? "x" : "y";
+    const isDate = types?.[axis] === "date";
+    interval = computeInterval(data, axis, isDate);
   }
 
   return {


### PR DESCRIPTION
Similar to #71, which added and `interval` argument for charts with a continuous date axis, this PR essentially adds support for histograms (with the bins computed at the query level). 

Currently, a `rectY` mark with a continuous x axis (and, conversely, a `rectX` mark with a continuous y axis) still displays the labels for each rect (as if it's a `band` scale). 

![image](https://github.com/user-attachments/assets/15c34137-16c2-4f56-8787-910587f64893)

This PR computes the smallest interval between adjacent marks to act as the `interval` argument, allowing Plot to implicitly bin the values (though, with the smallest interval being used, there will be no actual aggregation at the Plot level). 

As a result, we get a much better X axis:

![image](https://github.com/user-attachments/assets/ccfaf184-4890-42f5-8402-6c2dc2a2c3ae)

Works for `rectX` as well.

<img width="499" alt="Screenshot 2025-06-30 at 8 44 31 PM" src="https://github.com/user-attachments/assets/b5d4aba1-0bd3-43e4-a237-ed0a6d90f2d8" />
