### PR TITLE
Mf rawdata colors

### DIFF
--- a/examples/plots/index.js
+++ b/examples/plots/index.js
@@ -37,6 +37,7 @@ export * from "./percentageBarY.js";
 export * from "./percentageFacet.js";
 export * from "./pie.js";
 export * from "./rawData.js";
+export * from "./rawDataColor.js";
 export * from "./rawDataMultiChart.js";
 export * from "./rectX.js";
 export * from "./rectXfacet.js";

--- a/examples/plots/rawDataColor.js
+++ b/examples/plots/rawDataColor.js
@@ -1,0 +1,12 @@
+import { renderPlot } from "../util/renderPlotClient.js";
+// This code is both displayed in the browser and executed
+const codeString = `duckplot
+  .rawData([{col1: "a", col2: 5}, {col1: "b", col2: 2}, {col1: "c", col2: 3}], {col1: "string", col2: "number"})
+  .x("col1")
+  .y("col2")
+  .color("blue")  
+  .mark("barY")
+`;
+
+export const rawDataColor = (options) =>
+  renderPlot("stocks.csv", codeString, options);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -234,8 +234,14 @@ export const borderOptions = {
 };
 
 export const checkForConfigErrors = (instance: DuckPlot) => {
-  if (!instance.ddb) throw new Error("Database not set");
-  if (!instance.table()) throw new Error("Table not set");
+  const rawData = instance.rawData();
+  if (rawData && !rawData.types) {
+    throw new Error(
+      "You must include column types when specifying .rawData(data, types)"
+    );
+  }
+  if (!instance.ddb && !rawData) throw new Error("Database not set");
+  if (!instance.table() && !rawData) throw new Error("Table not set");
   const type = instance.mark().type;
   if (!type && !instance.markColumn().column)
     throw new Error("Mark type or mark column not set");
@@ -275,7 +281,7 @@ export const checkForConfigErrors = (instance: DuckPlot) => {
   // Using rawData and/or markColumn checks
   if (instance.markColumn().column && instance.rawData().length === 0)
     throw new Error("You must supply rawData to use markColumn");
-  if (instance.markColumn().column && instance.mark())
+  if (instance.markColumn().column && Object.keys(instance.mark()).length)
     throw new Error("You cannot use both a markColumn and a mark type");
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,6 +11,7 @@ import {
   TypesObject,
 } from "./types";
 import { DuckPlot } from ".";
+import { isColor } from "./options/getPlotOptions";
 
 export async function checkDistinct(
   duckDB: AsyncDuckDB,
@@ -158,8 +159,11 @@ export function processRawData(instance: DuckPlot): Data {
   if (!rawData || !rawData.types) return [];
 
   // Helper function to determine if a column defined
-  const colIsDefined = (col?: ColumnType): boolean =>
-    col !== "" && col !== undefined && typeof col === "string";
+  const colIsDefined = (key: string, col?: ColumnType): boolean =>
+    !(key === "series" && isColor(col)) &&
+    col !== "" &&
+    col !== undefined &&
+    typeof col === "string";
 
   // Define column mappings for data, types, and labels
   // TODO: if we rename series to color this should get simpler
@@ -178,7 +182,7 @@ export function processRawData(instance: DuckPlot): Data {
   const dataArray: Data = rawData.map((d) =>
     Object.fromEntries(
       columnMappings
-        .filter(({ column }) => colIsDefined(column))
+        .filter(({ key, column }) => colIsDefined(key, column))
         .map(({ key, column }) => [key, d[column as string]])
     )
   );
@@ -186,7 +190,7 @@ export function processRawData(instance: DuckPlot): Data {
   // Extract types based on the defined columns
   const dataTypes = Object.fromEntries(
     columnMappings
-      .filter(({ column }) => colIsDefined(column))
+      .filter(({ key, column }) => colIsDefined(key, column))
       .map(({ key, column }) => [key, rawData?.types?.[column as string]])
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export class DuckPlot {
   private _document: Document;
   private _newDataProps: boolean = true;
   private _data: Data = [];
-  private _rawData: Data = [];
+  private _rawData: Data | undefined = undefined;
   private _markColumn: MarkColumnProperty = {};
   private _config: Config = {};
   private _query: string = "";
@@ -243,13 +243,14 @@ export class DuckPlot {
   rawData(
     data?: Data,
     types?: { [key: string]: BasicColumnType }
-  ): Data | this {
-    if (data && types) {
+  ): Data | undefined | this {
+    if (data) {
       data.types = types;
       this._newDataProps = true;
       this._rawData = data;
       return this;
     }
+
     return this._rawData;
   }
 
@@ -275,6 +276,7 @@ export class DuckPlot {
   async prepareData(): Promise<Data> {
     // If no new data properties, return the data
     if (!this._newDataProps) return this._data;
+    checkForConfigErrors(this); // Will throw any errors
 
     // If there is raw data rather than a database, extract chart data from it
     if (this._rawData && this._rawData.types) {
@@ -285,7 +287,6 @@ export class DuckPlot {
       return this._data;
     }
 
-    checkForConfigErrors(this); // Will throw any errors
     this._newDataProps = false;
     this.visibleSeries = []; // reset visible series
     this.seriesDomain = []; // reset domain


### PR DESCRIPTION
Closes #102, closes #103. 

There were two issues with using `rawData` (for specifying an array of objects to work with). 

1. It wasn't clear that `types` needed to be set in `.rawData(data, types)` - now an error message is thrown
2. Users couldn't set a static color (e.g., `.color("blue")`) when using rawData because of an error in the `isColumnDefined` function. 

These have been resolved in this PR, and an example `rawDataColor` has been added and can be viewed when running `npm run dev`. 

New error message:
<img width="438" height="91" alt="Screenshot 2025-08-14 at 3 20 31 PM" src="https://github.com/user-attachments/assets/6b7beccb-114f-40e2-aae8-d588b22f71c7" />

New example:
<img width="536" height="495" alt="Screenshot 2025-08-14 at 3 40 30 PM" src="https://github.com/user-attachments/assets/7a18c996-65ef-4552-b4a6-c00438774124" />
